### PR TITLE
Fix on_session_module_run bug

### DIFF
--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -99,7 +99,7 @@ protected
       # Grab the session object since we need to fire an event for not
       # only the normal module_run event that all module types have to
       # report, but a specific event for sessions as well.
-      s = mod.framework.sessions[mod.datastore["SESSION"]]
+      s = mod.framework.sessions.get(mod.datastore["SESSION"].to_i)
       mod.framework.events.on_session_module_run(s, mod)
       mod.run
     rescue ::Timeout::Error => e


### PR DESCRIPTION
Should fix the bug catched by @wvu-r7 on https://github.com/rapid7/metasploit-framework/pull/2952, still any direct access to framework.sessions should be reviewed! This pull request is highly sensible!
