### PR TITLE
updates file read to close file more quickly

### DIFF
--- a/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
+++ b/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
@@ -46,9 +46,8 @@ class Metasploit3 < Msf::Auxiliary
     end
     if (turis_file && !turis_file.blank?)
       File.open(turis_file, 'rb') { |f| test_uris += f.readlines }
-      test_uris.each do |test_uri|
-        test_uri.chomp!
-        test_uris << normalize_uri(test_uri)
+      test_uris.collect! do |test_uri|
+        normalize_uri(test_uri.chomp)
       end
     end
     test_uris.each do |test_path|


### PR DESCRIPTION
cleaned up the returns which are unneccsary and changed the file read so it pulls out all the lines and then closes the file.  I did this because the scans could take a while and that file would be left open for quite a while.  This approach also isolates the file read to one line, vs it reading one for each iteration.  It may or may not be much better, but whatever, I think it's easier to look at and debug.  Let me know what you think.  I'm sorry for the additional PR.  I can def merge after this.  These changes aren't major in anyway, just idiomatic things.
Oh, I also wrapped one seriously long line and add a couple words to the description to reflect the behavior you altered after my last PR and I shortened some of the 'if result' lines.
