### PR TITLE
genericize http request plugin

### DIFF
--- a/plugins/request.rb
+++ b/plugins/request.rb
@@ -82,9 +82,9 @@ class Plugin::Requests < Msf::Plugin
         '-I' => [ false, 'Show document info only' ],
         '-o' => [ true,  'Write output to <file> instead of stdout' ],
         '-u' => [ true,  'Server user and password' ],
-        '-X' => [ true,  'Request method to use' ],
-        '-x' => [ true,  'Proxy to use, format: [proto://][user:pass@]host[:port]' +
-                          '  Proto defaults to http:// and port to 1080'],
+        '-X' => [ true,  'Request method to use' ]
+        #'-x' => [ true,  'Proxy to use, format: [proto://][user:pass@]host[:port]' +
+        #                 '  Proto defaults to http:// and port to 1080'],
       )
 
       options = {

--- a/plugins/request.rb
+++ b/plugins/request.rb
@@ -127,7 +127,12 @@ class Plugin::Requests < Msf::Plugin
         when '-o'
           options[:output_file] = File.expand_path(val)
         when '-u'
-          options[:auth_username] = val
+          val = val.split(':', 2) # only split on first ':' as per curl:
+          # from curl man page: "The user name and passwords are split up on the
+          # first colon, which makes it impossible to use a colon in the user
+          # name with this option.  The password can, still.
+          options[:auth_username] = val.first
+          options[:auth_password] = val.last
         when '-p'
           options[:auth_password] = val
         when '-X'
@@ -186,8 +191,6 @@ class Plugin::Requests < Msf::Plugin
         print_error('The connection was reset by the peer')
       rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
         print_error('Encountered an error')
-      #rescue ::Exception => ex
-      #  print_line("An error of type #{ex.class} happened, message is #{ex.message}")
       ensure
         http_client.close
       end


### PR DESCRIPTION
@zeroSteiner can you see if this still does what you expected out of the original PR?  Usage is pretty obvious, but:

```
load request
request
request -h
request -h https://www.google.com
request foo # invalid URI
request foo://www.google.com # unsupported URI type
request http://www.google.com --help
request https://www.google.com
```